### PR TITLE
Update map tile 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
+#secrets
+ApiKey.js
+
 # dependencies
 /node_modules
 

--- a/src/components/InteractiveMap.js
+++ b/src/components/InteractiveMap.js
@@ -4,6 +4,7 @@ import MarkerClusterGroup from 'react-leaflet-markercluster';
 import { SearchBar } from './SearchBar';
 import { geojson } from '../data/geojson';
 import { Config } from '../containers/Config';
+import { apikey } from '../containers/ApiKey';
 import '../containers/App.css';
 import '../data/geojson';
 
@@ -23,7 +24,10 @@ class InteractiveMap extends Component {
           zoom={Config.initialZoom}
           maxZoom={Config.maxZoom}
         >
-          <TileLayer url={Config.tileURL} attribution={Config.mapAttribution} />
+          <TileLayer
+            url={Config.tileURL + apikey.MAPBOX_ACCESS_TOKEN}
+            attribution={Config.mapAttribution}
+          />
           <MarkerClusterGroup>
             <GeoJSON data={geojson} onEachFeature={this.onEachFeature} />
           </MarkerClusterGroup>

--- a/src/components/InteractiveMap.js
+++ b/src/components/InteractiveMap.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Map, TileLayer, GeoJSON } from 'react-leaflet';
 import MarkerClusterGroup from 'react-leaflet-markercluster';
-import { SearchBar } from './SearchBar';
+import SearchBar from './SearchBar';
 import { geojson } from '../data/geojson';
 import { Config } from '../containers/Config';
 import { apikey } from '../containers/ApiKey';

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -4,13 +4,9 @@ import { geojson } from '../data/geojson';
 import SearchProvider from '../containers/SearchProvider';
 
 class Search extends MapControl {
-  static getSearchProvider() {
-    return new SearchProvider(geojson);
-  }
-
   createLeafletElement() {
     return GeoSearchControl({
-      provider: this.getSearchProvider(),
+      provider: new SearchProvider(geojson),
       autoClose: true,
       showPopup: true,
       searchLabel: 'search',

--- a/src/containers/ApiKey.js.sample
+++ b/src/containers/ApiKey.js.sample
@@ -1,0 +1,8 @@
+// IMPORTANT! DO NOT COMMIT THIS FILE!
+//
+// Replace the text 'YOUR MAPBOX ACCESS TOKEN' with your MapBox access token
+// and save and rename this file to 'ApiKey.js'.
+//
+const apikey = {
+  MAPBOX_ACCESS_TOKEN: 'YOUR MAPBOX ACCESS TOKEN'
+};

--- a/src/containers/Config.js
+++ b/src/containers/Config.js
@@ -3,7 +3,7 @@ export const Config = {
   initialZoom: 8,
   maxZoom: 18,
   tileURL:
-    'https://api.mapbox.com/styles/v1/marshallr2/cjmgpleyx0lri2tph0orws1m5/tiles/256/{z}/{x}/{y}@2x?access_token=',
+    'https://api.mapbox.com/styles/v1/norman-sicily-project/cjmm4r23s7n2b2rs0tq0a9rw0/tiles/256/{z}/{x}/{y}@2x?access_token=',
   mapAttribution:
     '<a href=&quot;https://www.mapbox.com/about/maps/&quot;>© Mapbox</a> <a href=&quot;http://www.openstreetmap.org/copyright&quot;>© OpenStreetMap</a>',
 };

--- a/src/containers/Config.js
+++ b/src/containers/Config.js
@@ -2,7 +2,8 @@ export const Config = {
   centerPoint: [37.73, 14.2],
   initialZoom: 8,
   maxZoom: 18,
-  tileURL: 'http://tile.stamen.com/terrain/{z}/{x}/{y}.jpg',
+  tileURL:
+    'https://api.mapbox.com/styles/v1/marshallr2/cjmgpleyx0lri2tph0orws1m5/tiles/256/{z}/{x}/{y}@2x?access_token=',
   mapAttribution:
-    'Map tiles by <a href=&quot;http://stamen.com&quot;>Stamen Design</a>, under <a href=&quot;http://creativecommons.org/licenses/by/3.0&quot;>CC BY 3.0</a>. Data by <a href=&quot;http://openstreetmap.org&quot;>OpenStreetMap</a>, under <a href=&quot;http://www.openstreetmap.org/copyright&quot;>ODbL</a>.',
+    '<a href=&quot;https://www.mapbox.com/about/maps/&quot;>© Mapbox</a> <a href=&quot;http://www.openstreetmap.org/copyright&quot;>© OpenStreetMap</a>',
 };


### PR DESCRIPTION
Adds ApiKey.js to store mapbox API key.
Updates tileURL and mapAttribution in Config.js to reflect the new tileset.
Adds dummy file with instructions for ApiKey.js 
Adds import in map for apikey and concatenated API key to map URL.

Not sure if I overloaded the map with layers. Seems to be an issue only in Firefox though from googling it may be on leaflets end.

Firefox issue: Will-change memory consumption is too high. Budget limit is the document surface area multiplied by 3 (1559040 px). Occurrences of will-change over the budget will be ignored.

Issue: #15 